### PR TITLE
fix: image, long/leti exception

### DIFF
--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -45,7 +45,7 @@ const Detail = () => {
               />
             ) : (
               <img
-                src={'../image/no-image'}
+                src={require('../image/no-image.png')}
                 style={{ height: 400, width: 400 }}
                 alt="img"
               />
@@ -72,7 +72,7 @@ const Detail = () => {
 
       <Fade duration={1000} delay={1400}>
         <Ccontainer>
-          {long !== 0 ? (
+          {long !== '0' ? (
             <div
               id="map"
               style={{ height: 400, width: '100%', borderRadius: '20px' }}


### PR DESCRIPTION
- 이미지가 없을 때 no-image로 대체하는 예외처리
- 위도/경도가 없을 때 지도가 나오지 않도록 예외처리 두 가지 예외처리 코드를 수정했습니다

by @seoyeon-jung