### PR TITLE
refactor ui

### DIFF
--- a/src/api.tsx
+++ b/src/api.tsx
@@ -23,7 +23,7 @@ export const getSearchData = async ({ queryKey }: any) => {
   let data;
   await axios
     .get(
-      `${BASE_URL}ccbaCtcd=${cityValue}&ccbaKdcd=${titleValue}&pageIndex=${pageNumber}&pageUnit=16`
+      `${BASE_URL}ccbaCtcd=${cityValue}&ccbaKdcd=${titleValue}&pageIndex=${pageNumber}&pageUnit=18`
     )
     .then((response) => {
       const responseData = new XMLParser().parseFromString(

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,8 +9,10 @@ export default function Footer() {
   );
   return (
     <FooterBox>
-      <div>Culture.map() | Soon`s Children | 내일배움캠프</div>
-      <div>총 방문자 수 : {visitData?.data()?.count}명</div>
+      <ContentBox>
+        <div>Culture.map() | Soon`s Children | 내일배움캠프</div>
+        <div>총 방문자 수 : {visitData?.data()?.count}명</div>
+      </ContentBox>
     </FooterBox>
   );
 }
@@ -21,6 +23,14 @@ const FooterBox = styled.div`
   color: white;
   height: 90px;
   padding: 0 20px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ContentBox = styled.div`
+  width: 1440px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,20 @@
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 export default function Header() {
+  const navigate = useNavigate();
   return (
     <HeaderContainer>
-      <ProjectName>Culture.map()</ProjectName>
-      <TeamName>순이와 아이들</TeamName>
+      <HeaderContents>
+        <ProjectName
+          onClick={() => {
+            navigate('/');
+          }}
+        >
+          Culture.map()
+        </ProjectName>
+        <TeamName>순이와 아이들</TeamName>
+      </HeaderContents>
     </HeaderContainer>
   );
 }
@@ -13,7 +23,14 @@ const HeaderContainer = styled.div`
   font-family: 'Gugi', cursive;
   background-color: #242c44;
   color: white;
-  height: 50px;
+  height: 60px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+`;
+const HeaderContents = styled.div`
+  max-width: 1920px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -21,6 +38,7 @@ const HeaderContainer = styled.div`
 `;
 const ProjectName = styled.div`
   font-size: 25px;
+  cursor: pointer;
 `;
 const TeamName = styled.div`
   font-size: 15px;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,7 +30,7 @@ const HeaderContainer = styled.div`
   align-items: center;
 `;
 const HeaderContents = styled.div`
-  width: 1920px;
+  width: 1440px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,7 +30,7 @@ const HeaderContainer = styled.div`
   align-items: center;
 `;
 const HeaderContents = styled.div`
-  max-width: 1920px;
+  width: 1920px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -57,7 +57,7 @@ export default ListItem;
 
 const ItemContainer = styled.div`
   display: flex;
-  width: 700px;
+  width: 460px;
   height: 700px;
   margin: 20px 0;
 `;
@@ -66,7 +66,7 @@ const ItemTopWrap = styled.div<ItemTopWrapProps>`
   background-position: center;
   background-size: cover;
   height: 500px;
-  width: 700px;
+  width: 460px;
   background-image: ${(props) =>
     props.image !== ''
       ? `linear-gradient(#000000d1, #0000008b), url(${props.image})`
@@ -91,22 +91,28 @@ const NameGeneWarp = styled.div`
 
 const TopName = styled.div`
   writing-mode: vertical-rl;
-  text-orientation: upright;
+  /* text-orientation: upright; */
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 
   font-size: 48px;
+  font-weight: 600;
+  letter-spacing: 4px;
   margin: 40px 40px 40px 0;
 `;
 const TopGene = styled.div`
   writing-mode: vertical-rl;
-  text-orientation: upright;
+  /* text-orientation: upright; */
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 24px;
+
+  font-size: 32px;
+  letter-spacing: 2px;
+
   margin-top: 40px;
+  margin-right: 16px;
 `;
 
 const ContentBody = styled.div`
@@ -120,6 +126,7 @@ const ContentText = styled.span`
   font-weight: 100;
   line-height: 30px;
   color: white;
+  text-align: justify;
 
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/MainCarousel.tsx
+++ b/src/components/MainCarousel.tsx
@@ -4,6 +4,10 @@ import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import styled from 'styled-components';
 
+interface ImgBoxProps {
+  mainImg: string;
+}
+
 const MainCarousel = () => {
   const mainImg01 = './image/mainVisual/mainVisual01.jpg';
   const mainImg02 = './image/mainVisual/mainVisual02.jpg';
@@ -13,13 +17,43 @@ const MainCarousel = () => {
     <Wrapper>
       <StyledSlider {...settings}>
         <CarouselBox>
-          <Img src={mainImg01} />
+          <ImgBox mainImg={mainImg01}>
+            <Script>
+              <Title>천정문</Title>
+              <Generation>백제시대</Generation>
+              <Contents>사비성을 재현해놓은 사비궁의 중남문</Contents>
+            </Script>
+          </ImgBox>
         </CarouselBox>
         <CarouselBox>
-          <Img src={mainImg02} />
+          <ImgBox mainImg={mainImg02}>
+            <Script>
+              <Title>경복궁 경회루</Title>
+              <Generation>조선시대</Generation>
+              <Contents>
+                1985년 국보로 지정되었다.정면 7칸, 측면 5칸의 중층(重層)
+                팔작지붕건물.
+                <br />
+                근정전 서북쪽에 있는 방형 연못 안에 세운 이 건물은 나라의 경사가
+                있을 때 연회를 베풀기 위한 곳이었다.
+              </Contents>
+            </Script>
+          </ImgBox>
         </CarouselBox>
         <CarouselBox>
-          <Img src={mainImg03} />
+          <ImgBox mainImg={mainImg03}>
+            <Script>
+              <Title>사물놀이</Title>
+              <Generation>1978 년 ~</Generation>
+              <Contents>
+                사물놀이는 사물(四物), 꽹과리 · 장구 · 북 · 징의 네 가지 악기
+                놀이[연주]라는 의미이다.
+                <br />
+                사물놀이는 야외에서 이루어지는 대규모 구성의 풍물놀이를 1978년
+                무대예술로 각색한 것이다.
+              </Contents>
+            </Script>
+          </ImgBox>
         </CarouselBox>
       </StyledSlider>
     </Wrapper>
@@ -65,10 +99,36 @@ const CarouselBox = styled.div`
   display: flex;
 `;
 
-const Img = styled.img`
+const ImgBox = styled.div<ImgBoxProps>`
   width: 100%;
   height: 550px;
   margin: 0 auto;
+  background-image: ${(props) => `url(${props.mainImg})`};
+`;
+
+const Script = styled.div`
+  width: 1440px;
+  margin: 0 auto;
+  padding-top: 120px;
+`;
+
+const Title = styled.p`
+  font-size: 48px;
+  color: white;
+  margin-bottom: 16px;
+  font-weight: 600;
+`;
+
+const Generation = styled.p`
+  color: #eee;
+  font-size: 32px;
+  margin-bottom: 40px;
+`;
+
+const Contents = styled.p`
+  color: #ddd;
+  font-size: 24px;
+  line-height: 32px;
 `;
 
 export default MainCarousel;

--- a/src/components/MapKakao.tsx
+++ b/src/components/MapKakao.tsx
@@ -1,12 +1,26 @@
-import React from 'react';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
+import styled from 'styled-components';
 
-export default function MapKakao({ lat, lng }: { lat: number; lng: number }) {
+export default function MapKakao({
+  lat,
+  lng,
+  title,
+}: {
+  lat: number;
+  lng: number;
+  title: string;
+}) {
   return (
     <Map center={{ lat, lng }} style={{ width: '100%', height: '360px' }}>
-      <MapMarker position={{ lat: 33.55635, lng: 126.795841 }}>
-        <div style={{ color: '#000' }}>Hello World!</div>
+      <MapMarker position={{ lat, lng }}>
+        {/* <MarkerName>{title}</MarkerName> */}
       </MapMarker>
     </Map>
   );
 }
+
+const MarkerName = styled.div`
+  color: black;
+  width: 110%;
+  background-color: #ff0000a0;
+`;

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -7,7 +7,7 @@ function Pagination(props: any) {
   let firstNum = currPage - (currPage % 5) + 1;
   let lastNum = currPage - (currPage % 5) + 5;
 
-  const numPages = Math.ceil(total / 16);
+  const numPages = Math.ceil(total / 18);
   // 16736은 전체페이지수이긴 하나, total로 가져오려고 하니 total이 빈배열로
   // 나와서 어쩔수 없이 16736으로 표기
   useEffect(() => {
@@ -19,10 +19,10 @@ function Pagination(props: any) {
       <Nav>
         <Button
           onClick={() => {
-            setPage(Number(page) - 1);
-            setCurrPage(Number(page) - 2);
+            setPage(page - 1);
+            setCurrPage(page - 2);
           }}
-          disabled={page == 1}
+          disabled={page === 1}
         >
           &lt;
         </Button>
@@ -80,7 +80,7 @@ function Pagination(props: any) {
 
         <Button
           onClick={() => {
-            setPage(Number(page) + 1);
+            setPage(page + 1);
             setCurrPage(page);
           }}
           disabled={page === numPages}

--- a/src/components/ReviewItem.tsx
+++ b/src/components/ReviewItem.tsx
@@ -12,48 +12,75 @@ function ReviewItem({ item }: { item: reviewType }) {
   };
 
   return (
-    <div>
-      {deleteToggle ? (
-        <Modal item={item} setDeleteToggle={setDeleteToggle} />
-      ) : (
-        <div></div>
-      )}
-      <Wrap>
-        <NameDiv>
-          <BiUser />
-          &nbsp; {item?.name}
-        </NameDiv>
-        <BodyDiv>{item?.body}</BodyDiv>
+    <Wrap>
+      <Container>
+        {deleteToggle ? (
+          <Modal item={item} setDeleteToggle={setDeleteToggle} />
+        ) : (
+          <></>
+        )}
+        <ContentBox>
+          <NameDiv>
+            <BiUser size="24" />
+            &nbsp; {item?.name}
+          </NameDiv>
+          <BodyDiv>{item?.body}</BodyDiv>
+        </ContentBox>
+
         <DeleteBtn onClick={removeModal}>
-          <FiTrash2 size="15" />
+          <FiTrash2 size="24" />
         </DeleteBtn>
-      </Wrap>
-    </div>
+      </Container>
+    </Wrap>
   );
 }
 
 export default ReviewItem;
 
 const Wrap = styled.div`
-  width: 700px;
-  margin: 25px;
+  margin-top: 20px;
+`;
+
+const Container = styled.div`
+  width: 1400px;
+  height: 80px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background-color: #efefef84;
+  padding: 0 20px;
+
+  border-radius: 10px;
+
+  background-color: #eee;
+  margin-bottom: 20px;
 `;
+
+const ContentBox = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 80px;
+`;
+
 const NameDiv = styled.div`
   margin: 10px;
+  width: 200px;
+  font-size: 18px;
+  border-right: 1px solid #333;
+  display: flex;
+  align-items: center;
 `;
 
 const BodyDiv = styled.div`
   margin: 10px;
+  font-size: 18px;
 `;
 
 const DeleteBtn = styled.button`
   margin: 10px;
   border: none;
-  background-color: #efefef84;
+  background-color: #ffffff00;
+  cursor: pointer;
   &:hover {
     transform: scale(1.2);
   }

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -71,7 +71,7 @@ const Detail = () => {
 
       <Fade duration={1000} delay={1400}>
         <Ccontainer>
-          <MapKakao lat={lat} lng={long} />
+          <MapKakao lat={lat} lng={long} title={name} />
         </Ccontainer>
       </Fade>
       <ReviewListWrap>

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -74,6 +74,7 @@ const Detail = () => {
           <MapKakao lat={lat} lng={long} title={name} />
         </Ccontainer>
       </Fade>
+
       <ReviewListWrap>
         <Fade duration={1000} delay={1500}>
           <ReviewButton
@@ -94,9 +95,11 @@ export default Detail;
 
 const Container = styled.div`
   font-family: 'Noto Sans KR', sans-serif;
-  margin-inline: 100px;
-  margin-top: 50px;
-  margin-bottom: 50px;
+  width: 1440px;
+  margin: 30px auto 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;
 
 const Acontainer = styled.div`
@@ -104,6 +107,7 @@ const Acontainer = styled.div`
   flex-direction: row;
   justify-content: center;
   align-items: center;
+  width: 1440px;
 `;
 
 const A1container = styled.div``;
@@ -132,13 +136,21 @@ const SubName = styled.div`
   font-size: 20px;
   font-weight: 500;
   margin-bottom: 5px;
+  font-size: 24px;
+  line-height: 30px;
 `;
 
 const Bcontainer = styled.div`
   margin-top: 50px;
+  font-size: 18px;
+  line-height: 28px;
 `;
 const Ccontainer = styled.div`
   margin-top: 50px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  width: 1440px;
 `;
 const ReviewListWrap = styled.div`
   display: flex;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -13,7 +13,7 @@ const Main = () => {
   const [titleValue, setTitleValue] = useState('');
   const [submitCity, setSubmitCity] = useState('');
   const [submitTitle, setSubmitTitle] = useState('');
-  const [pageNumber, setPageNumber] = useState('1');
+  const [pageNumber, setPageNumber] = useState(1);
 
   const queryClient = useQueryClient();
 
@@ -35,7 +35,7 @@ const Main = () => {
   const page: number = Math.ceil(pageIndexData / 16);
 
   const handleSearchBtnClick = (cityValue: string, titleValue: string) => {
-    setPageNumber('1');
+    setPageNumber(1);
     setSubmitCity(cityValue);
     setSubmitTitle(titleValue);
   };
@@ -47,9 +47,6 @@ const Main = () => {
     setTitleValue(event.target.value);
   };
 
-  const clickPageNumber = (event: React.MouseEvent) => {
-    setPageNumber((event.target as HTMLInputElement).value);
-  };
   const pages = [];
   for (let i = 1; i < page + 1; i++) {
     pages.push(i);


### PR DESCRIPTION
### 메인 페이지
- 메인비주얼에 내용을 추가했습니다.
- 아이템 리스트를 2개 - > 3개 로 변경했습니다.
- 아이템 리스트의 제목, 시대의 자간, 폰트굵기를 변경했습니다.
- 아이템 리스트의 설명을 text-align : justify 로 변경했습니다.
- 아이템 리스트의 갯수 16->18개로 변경했습니다.

---

### 헤더
- 헤더 컨텐츠의 width 값을 1440px로 변경했습니다.
- 헤더의 Culture.Map() 을 누르면 메인페이지로 이동하도록 변경했습니다.
- 헤더 height 값을 50 -> 60 px로 변경했습니다.

---

### 푸터
- 푸터 컨텐츠의 width 값을 1440px로 변경했습니다.

---

### 디테일 페이지
- Map 의 타이틀을 삭제했습니다.
- 전체적인 css를 변경했습니다.
- 리뷰 css를 변경했습니다.

by @GoMyamMii 